### PR TITLE
Implement color tagging and UI improvements

### DIFF
--- a/public/setup.html
+++ b/public/setup.html
@@ -10,7 +10,7 @@
   <header class="navbar">
     <div class="navbar-left">Cesana Timing</div>
     <div class="navbar-right">
-      <a href="timing.html" class="nav-link">Tempi Live</a>
+      <a href="timing.html" class="nav-link">Tempi</a>
       <a href="setup.html" class="nav-link active">Setup</a>
       <button id="theme-toggle" class="theme-toggle">🌙</button>
     </div>
@@ -32,10 +32,21 @@
 
     <!-- Aggiungi Associazioni -->
     <h1>Aggiungi Associazioni</h1>
-    <form id="form">
-      <select id="uuid" required></select>
-      <input type="text" id="name" placeholder="Nome utente" required>
-      <br>
+    <form id="form" class="assoc-form">
+      <div class="form-grid">
+        <div>
+          <select id="uuid"></select>
+        </div>
+        <div>
+          <div id="color-picker" class="color-picker"></div>
+        </div>
+        <div>
+          <input type="text" id="uuid-manual" placeholder="UID manuale">
+        </div>
+        <div>
+          <input type="text" id="name" placeholder="Nome utente" required>
+        </div>
+      </div>
       <button type="submit">Salva</button>
     </form>
 
@@ -92,18 +103,38 @@
     // Tags CRUD
     const form = document.getElementById('form'),
           uuidSel = document.getElementById('uuid'),
+          uuidManual = document.getElementById('uuid-manual'),
+          colorPicker = document.getElementById('color-picker'),
           tagsTbody = document.getElementById('tags-tbody');
+    const colors = [
+      '#ff0000', '#ff8000', '#ffff00', '#80ff80',
+      '#008000', '#00c8ff', '#0000ff', '#8000ff'
+    ];
+    let selectedColor = null;
+    colors.forEach(c => {
+      const d = document.createElement('div');
+      d.className = 'color-option';
+      d.style.backgroundColor = c;
+      d.addEventListener('click', () => {
+        selectedColor = c;
+        document.querySelectorAll('.color-option').forEach(el => el.classList.remove('selected'));
+        d.classList.add('selected');
+      });
+      colorPicker.appendChild(d);
+    });
     form.addEventListener('submit', async e=>{
       e.preventDefault();
-      const uuid = uuidSel.value,
+      const uuid = (uuidManual.value.trim()) || uuidSel.value,
             name = document.getElementById('name').value.trim();
-      if(!uuid||!name) return;
+      if(!uuid || !name) return;
       await fetch('/api/tags',{
         method:'POST',
         headers:{'Content-Type':'application/json'},
-        body:JSON.stringify({uuid,name})
+        body:JSON.stringify({uuid,name,color:selectedColor})
       });
       form.reset();
+      selectedColor = null;
+      document.querySelectorAll('.color-option').forEach(el => el.classList.remove('selected'));
       loadTags();
       loadUnassigned();
     });
@@ -123,6 +154,9 @@
           <td>${r.name}</td>
           <td><button onclick="deleteTag('${r.uuid}')">Elimina</button></td>
         `;
+        if(r.color){
+          tr.style.backgroundColor = r.color;
+        }
         tagsTbody.appendChild(tr);
       });
     }

--- a/public/style.css
+++ b/public/style.css
@@ -76,6 +76,14 @@ body {
   font-size: 1.2rem;
   cursor: pointer;
   color: var(--nav-text);
+  padding: 0;
+  margin-left: 0.25rem;
+}
+
+.theme-toggle:hover,
+.theme-toggle:focus {
+  background: none;
+  outline: none;
 }
 
 /* Status Cronometro */
@@ -123,6 +131,14 @@ th { background: var(--table-header-bg); }
 form {
   margin-bottom: 1rem;
   text-align: center;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.5rem;
+  align-items: center;
+  justify-items: center;
 }
 
 input {
@@ -178,4 +194,25 @@ button:hover { background: var(--nav-hover); }
 .setup-container .db-section h3 {
   font-size: 1.2rem;
   margin: 1rem 0 0.5rem;
+}
+
+/* Color picker */
+.color-picker {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+.color-option {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  border: 2px solid transparent;
+  cursor: pointer;
+}
+
+.color-option.selected {
+  border-color: #ffffff;
 }

--- a/public/timing.html
+++ b/public/timing.html
@@ -3,21 +3,21 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Tempi Live - Cesana Timing</title>
+  <title>Tempi - Cesana Timing</title>
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
   <header class="navbar">
     <div class="navbar-left">Cesana Timing</div>
     <div class="navbar-right">
-      <a href="timing.html" class="nav-link active">Tempi Live</a>
+      <a href="timing.html" class="nav-link active">Tempi</a>
       <a href="setup.html" class="nav-link">Setup</a>
       <button id="theme-toggle" class="theme-toggle">🌙</button>
     </div>
   </header>
 
   <main class="container">
-    <h1>Tempi Live</h1>
+    <h1>Tempi</h1>
     <table>
       <thead>
         <tr>
@@ -57,6 +57,9 @@
           <td>${r.elapsed}</td>
           <td class="start-time-col">${r.start_time}</td>
         `;
+        if(r.color){
+          tr.style.backgroundColor = r.color;
+        }
         tbody.appendChild(tr);
       });
     }


### PR DESCRIPTION
## Summary
- add color field to tag database and adjust API responses
- reduce nav label size and fix theme toggle styles
- support manual UID entry and color selection
- show color-coded rows in setup and timing pages
- simplify time formatting

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6884e26d01f4832a9ae41624b12d6646