### PR TITLE
Improve setup layout and row colorization

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,9 +71,17 @@ assocDb.serialize(() => {
   assocDb.run(`
     CREATE TABLE IF NOT EXISTS tags (
       uuid TEXT PRIMARY KEY,
-      name TEXT NOT NULL
+      name TEXT NOT NULL,
+      color TEXT
     )
   `, () => console.log('[DEBUG] Tabella tags pronta'));
+
+  // Aggiorna lo schema esistente con la colonna colore se necessario
+  assocDb.run(`ALTER TABLE tags ADD COLUMN color TEXT`, err => {
+    if (err && !/duplicate column/.test(err.message)) {
+      console.error('[ERROR] ALTER TABLE tags:', err.message);
+    }
+  });
 });
 
 // --- Stato gates e variabili temporanee cronometro ---
@@ -180,6 +188,7 @@ app.get('/api/timings', (req, res) => {
     SELECT
       t.tag_id,
       assocdb.tags.name   AS tag_name,
+      assocdb.tags.color  AS tag_color,
       t.start_time,
       t.elapsed_ms,
       t.created_at
@@ -197,7 +206,8 @@ app.get('/api/timings', (req, res) => {
             m  = Math.floor((ms%3600000)/60000),
             s  = Math.floor((ms%60000)/1000),
             cs = Math.floor((ms%1000)/10);
-      return `${pad(h)}:${pad(m)}:${pad(s)}.${pad(cs)}`;
+      const base = `${pad(m)}:${pad(s)}.${pad(cs)}`;
+      return h>0 ? `${pad(h)}:${base}` : base;
     };
 
     res.json(rows.map(r => {
@@ -213,7 +223,8 @@ app.get('/api/timings', (req, res) => {
         name:       displayName,
         start_time: r.start_time,
         elapsed:    format(r.elapsed_ms),
-        created_at: r.created_at
+        created_at: r.created_at,
+        color:      r.tag_color
       };
     }));
   });
@@ -226,16 +237,16 @@ app.get('/api/status', (req, res) => {
 
 // --- API Tags CRUD ---
 app.get('/api/tags', (req, res) => {
-  assocDb.all(`SELECT uuid,name FROM tags`, (err, rows) => {
+  assocDb.all(`SELECT uuid,name,color FROM tags`, (err, rows) => {
     if (err) return res.status(500).json({ error: err.message });
     res.json(rows);
   });
 });
 app.post('/api/tags', (req, res) => {
-  const { uuid, name } = req.body;
+  const { uuid, name, color } = req.body;
   assocDb.run(
-    `INSERT OR REPLACE INTO tags(uuid,name) VALUES(?,?)`,
-    [uuid.trim(), name.trim()],
+    `INSERT OR REPLACE INTO tags(uuid,name,color) VALUES(?,?,?)`,
+    [uuid.trim(), name.trim(), color || null],
     err => err
       ? res.status(500).json({ error: err.message })
       : res.sendStatus(200)

--- a/public/setup.html
+++ b/public/setup.html
@@ -10,7 +10,7 @@
   <header class="navbar">
     <div class="navbar-left">Cesana Timing</div>
     <div class="navbar-right">
-      <a href="timing.html" class="nav-link">Tempi Live</a>
+      <a href="timing.html" class="nav-link">Tempi</a>
       <a href="setup.html" class="nav-link active">Setup</a>
       <button id="theme-toggle" class="theme-toggle">🌙</button>
     </div>
@@ -33,9 +33,21 @@
     <!-- Aggiungi Associazioni -->
     <h1>Aggiungi Associazioni</h1>
     <form id="form">
-      <select id="uuid" required></select>
-      <input type="text" id="name" placeholder="Nome utente" required>
-      <br>
+      <div class="form-grid">
+        <select id="uuid"></select>
+        <div id="color-picker" class="color-picker">
+          <div class="color-swatch" data-color="#ff0000" style="background:#ff0000"></div>
+          <div class="color-swatch" data-color="#ff8800" style="background:#ff8800"></div>
+          <div class="color-swatch" data-color="#ffff00" style="background:#ffff00"></div>
+          <div class="color-swatch" data-color="#80ff80" style="background:#80ff80"></div>
+          <div class="color-swatch" data-color="#008000" style="background:#008000"></div>
+          <div class="color-swatch" data-color="#00ffff" style="background:#00ffff"></div>
+          <div class="color-swatch" data-color="#0000ff" style="background:#0000ff"></div>
+          <div class="color-swatch" data-color="#800080" style="background:#800080"></div>
+        </div>
+        <input type="text" id="uuid-manual" placeholder="UID manuale">
+        <input type="text" id="name" placeholder="Nome utente" required>
+      </div>
       <button type="submit">Salva</button>
     </form>
 
@@ -92,18 +104,31 @@
     // Tags CRUD
     const form = document.getElementById('form'),
           uuidSel = document.getElementById('uuid'),
+          uuidManual = document.getElementById('uuid-manual'),
+          colorPicker = document.getElementById('color-picker'),
           tagsTbody = document.getElementById('tags-tbody');
+
+    let selectedColor = '';
+    colorPicker.querySelectorAll('.color-swatch').forEach(el => {
+      el.addEventListener('click', () => {
+        colorPicker.querySelectorAll('.color-swatch').forEach(s => s.classList.remove('selected'));
+        el.classList.add('selected');
+        selectedColor = el.dataset.color;
+      });
+    });
     form.addEventListener('submit', async e=>{
       e.preventDefault();
-      const uuid = uuidSel.value,
+      const uuid = uuidSel.value || uuidManual.value.trim(),
             name = document.getElementById('name').value.trim();
       if(!uuid||!name) return;
       await fetch('/api/tags',{
         method:'POST',
         headers:{'Content-Type':'application/json'},
-        body:JSON.stringify({uuid,name})
+        body:JSON.stringify({uuid,name,color:selectedColor})
       });
       form.reset();
+      selectedColor = '';
+      colorPicker.querySelectorAll('.color-swatch').forEach(s => s.classList.remove('selected'));
       loadTags();
       loadUnassigned();
     });
@@ -123,6 +148,9 @@
           <td>${r.name}</td>
           <td><button onclick="deleteTag('${r.uuid}')">Elimina</button></td>
         `;
+        if(r.color){
+          tr.style.background = r.color + '33';
+        }
         tagsTbody.appendChild(tr);
       });
     }

--- a/public/style.css
+++ b/public/style.css
@@ -76,6 +76,12 @@ body {
   font-size: 1.2rem;
   cursor: pointer;
   color: var(--nav-text);
+  padding: 0;
+  margin: 0;
+}
+
+.theme-toggle:focus {
+  outline: none;
 }
 
 /* Status Cronometro */
@@ -125,9 +131,16 @@ form {
   text-align: center;
 }
 
+.form-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.5rem;
+  justify-items: center;
+}
+
 input {
-  width: calc(100% - 100px);
-  max-width: 200px;
+  width: 100%;
+  max-width: 250px;
   padding: 6px 10px;
   margin: 0.5rem;
   border: 1px solid var(--table-border);
@@ -135,8 +148,8 @@ input {
   color: var(--text-color);
 }
 select {
-  width: calc(100% - 100px);
-  max-width: 200px;
+  width: 100%;
+  max-width: 250px;
   padding: 6px 10px;
   margin: 0.5rem;
   border: 1px solid var(--table-border);
@@ -154,6 +167,10 @@ button {
   border: none;
   border-radius: 0.5rem;
   margin: 0.5rem;
+}
+
+table button {
+  margin: 0;
 }
 
 button:hover { background: var(--nav-hover); }
@@ -178,4 +195,31 @@ button:hover { background: var(--nav-hover); }
 .setup-container .db-section h3 {
   font-size: 1.2rem;
   margin: 1rem 0 0.5rem;
+}
+
+/* Color picker */
+.color-picker {
+  display: grid;
+  grid-template-columns: repeat(8, 1fr);
+  gap: 0.5rem;
+  margin: 0.5rem 0;
+}
+
+.color-swatch {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  border: 2px solid transparent;
+  cursor: pointer;
+  margin: auto;
+}
+
+.color-swatch.selected {
+  border-color: #ffffff;
+}
+
+@media (max-width: 600px) {
+  .color-picker {
+    grid-template-columns: repeat(4, 1fr);
+  }
 }

--- a/public/timing.html
+++ b/public/timing.html
@@ -10,7 +10,7 @@
   <header class="navbar">
     <div class="navbar-left">Cesana Timing</div>
     <div class="navbar-right">
-      <a href="timing.html" class="nav-link active">Tempi Live</a>
+      <a href="timing.html" class="nav-link active">Tempi</a>
       <a href="setup.html" class="nav-link">Setup</a>
       <button id="theme-toggle" class="theme-toggle">🌙</button>
     </div>
@@ -57,6 +57,9 @@
           <td>${r.elapsed}</td>
           <td class="start-time-col">${r.start_time}</td>
         `;
+        if(r.color){
+          tr.style.background = r.color + '33';
+        }
         tbody.appendChild(tr);
       });
     }


### PR DESCRIPTION
## Summary
- size inputs consistently and remove table button margin
- show eight color choices as a 4x2 grid on mobile
- apply 20% opacity to colored rows

## Testing
- `node index.js >/tmp/run.log 2>&1 &` *(server started then terminated)*

------
https://chatgpt.com/codex/tasks/task_e_6884e26d01f4832a9ae41624b12d6646