### PR TITLE
Fix layout, unify fields and add color transparency

### DIFF
--- a/public/setup.html
+++ b/public/setup.html
@@ -81,6 +81,15 @@
       toggle.textContent = isDark?'☀️':'🌙';
     });
 
+    function hexToRGBA(hex, alpha) {
+      const h = hex.replace('#', '');
+      const bigint = parseInt(h, 16);
+      const r = (bigint >> 16) & 255;
+      const g = (bigint >> 8) & 255;
+      const b = bigint & 255;
+      return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+    }
+
     // Status gate
     async function loadStatus(){
       try {
@@ -155,7 +164,7 @@
           <td><button onclick="deleteTag('${r.uuid}')">Elimina</button></td>
         `;
         if(r.color){
-          tr.style.backgroundColor = r.color;
+          tr.style.backgroundColor = hexToRGBA(r.color, 0.2);
         }
         tagsTbody.appendChild(tr);
       });

--- a/public/style.css
+++ b/public/style.css
@@ -32,7 +32,7 @@ body {
 }
 
 .container {
-  max-width: 600px;
+  max-width: 700px;
   margin: 0 auto;
   padding: 1rem;
 }
@@ -142,8 +142,8 @@ form {
 }
 
 input {
-  width: calc(100% - 100px);
-  max-width: 200px;
+  width: 100%;
+  max-width: 300px;
   padding: 6px 10px;
   margin: 0.5rem;
   border: 1px solid var(--table-border);
@@ -151,8 +151,8 @@ input {
   color: var(--text-color);
 }
 select {
-  width: calc(100% - 100px);
-  max-width: 200px;
+  width: 100%;
+  max-width: 300px;
   padding: 6px 10px;
   margin: 0.5rem;
   border: 1px solid var(--table-border);
@@ -172,6 +172,11 @@ button {
   margin: 0.5rem;
 }
 
+table button {
+  width: auto;
+  margin: 0;
+}
+
 button:hover { background: var(--nav-hover); }
 
 /* Responsive */
@@ -180,6 +185,13 @@ button:hover { background: var(--nav-hover); }
   input, select, button {
     width: 100%;
     margin-bottom: 8px;
+  }
+  table button {
+    width: auto;
+    margin: 0;
+  }
+  .color-picker {
+    grid-template-columns: repeat(4, 24px);
   }
 }
 
@@ -198,8 +210,8 @@ button:hover { background: var(--nav-hover); }
 
 /* Color picker */
 .color-picker {
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: repeat(8, 24px);
   justify-content: center;
   gap: 0.5rem;
   margin-top: 0.5rem;

--- a/public/timing.html
+++ b/public/timing.html
@@ -17,7 +17,7 @@
   </header>
 
   <main class="container">
-    <h1>Tempi</h1>
+    <h1>Tempi Live</h1>
     <table>
       <thead>
         <tr>
@@ -44,6 +44,15 @@
       toggle.textContent = isDark?'☀️':'🌙';
     });
 
+    function hexToRGBA(hex, alpha) {
+      const h = hex.replace('#', '');
+      const bigint = parseInt(h, 16);
+      const r = (bigint >> 16) & 255;
+      const g = (bigint >> 8) & 255;
+      const b = bigint & 255;
+      return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+    }
+
     // Carica cronometri
     async function load() {
       const res  = await fetch('/api/timings');
@@ -58,7 +67,7 @@
           <td class="start-time-col">${r.start_time}</td>
         `;
         if(r.color){
-          tr.style.backgroundColor = r.color;
+          tr.style.backgroundColor = hexToRGBA(r.color, 0.2);
         }
         tbody.appendChild(tr);
       });


### PR DESCRIPTION
## Summary
- keep the page header as "Tempi Live"
- add helper to convert association colors to rgba
- adjust form element sizes and color picker layout
- widen container on desktop and tweak button styles

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6884fc09db00832a87204f493222ca3b