### PR TITLE
Organize files and tweak setup UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# Cesana Timing
+
+Applicazione Node.js per gestire un semplice sistema di cronometraggio tramite MQTT e database SQLite.
+
+## Installazione
+
+1. Clona il repository e posizionati nella cartella del progetto.
+2. Installa le dipendenze:
+   ```bash
+   npm install
+   ```
+3. Configura `config.json` impostando credenziali MQTT, porta del web server e percorsi dei database.
+4. Avvia il server:
+   ```bash
+   node index.js
+   ```
+5. Visita `http://localhost:3000/` (o la porta configurata) per la schermata dei tempi. La pagina di setup si trova a `/setup.html` e richiede autenticazione.
+
+## Struttura cartelle
+
+- **html/** contiene i file HTML (`timing.html` e `setup.html`).
+- **css/** contiene i fogli di stile.
+- **data/** verrà creata automaticamente e conterrà i database SQLite.
+
+## Utilizzo
+
+- Nella pagina **Setup** è possibile associare un colore e un nome agli UUID rilevati o inseriti manualmente, oltre a gestire i database.
+- Nella pagina **Tempi** vengono mostrati in tempo reale i cronometraggi ricevuti via MQTT.
+

--- a/css/style.css
+++ b/css/style.css
@@ -190,8 +190,8 @@ button:hover { background: var(--nav-hover); }
     width: auto;
     margin: 0;
   }
-  .color-picker {
-    grid-template-columns: repeat(4, 24px);
+  .form-grid {
+    grid-template-columns: 1fr;
   }
 }
 
@@ -211,7 +211,7 @@ button:hover { background: var(--nav-hover); }
 /* Color picker */
 .color-picker {
   display: grid;
-  grid-template-columns: repeat(8, 24px);
+  grid-template-columns: repeat(4, 24px);
   justify-content: center;
   gap: 0.5rem;
   margin-top: 0.5rem;

--- a/html/setup.html
+++ b/html/setup.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Setup - Cesana Timing</title>
-  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="/css/style.css">
 </head>
 <body>
   <header class="navbar">
@@ -123,7 +123,8 @@
     colors.forEach(c => {
       const d = document.createElement('div');
       d.className = 'color-option';
-      d.style.backgroundColor = c;
+      d.style.backgroundColor = hexToRGBA(c, 0.2);
+      d.style.borderColor = c;
       d.addEventListener('click', () => {
         selectedColor = c;
         document.querySelectorAll('.color-option').forEach(el => el.classList.remove('selected'));

--- a/html/timing.html
+++ b/html/timing.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Tempi - Cesana Timing</title>
-  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="/css/style.css">
 </head>
 <body>
   <header class="navbar">

--- a/index.js
+++ b/index.js
@@ -179,8 +179,9 @@ app.use((req, res, next) => {
   next();
 });
 
-// Serve static files (timing.html di default)
-app.use(express.static(path.join(__dirname, 'public'), { index: 'timing.html' }));
+// Serve static files separati per HTML e CSS (timing.html di default)
+app.use('/css', express.static(path.join(__dirname, 'css')));
+app.use(express.static(path.join(__dirname, 'html'), { index: 'timing.html' }));
 
 // --- API: elenco cronometri con logica nome/UUID/Sconosciuto ---
 app.get('/api/timings', (req, res) => {


### PR DESCRIPTION
## Summary
- move static files into `html` and `css` folders
- adapt server to serve new paths
- tweak setup color picker and responsive layout
- add simple usage instructions in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68850842d3d8832aa6d37d22d6f71cb2