### PR TITLE
Fix root route

### DIFF
--- a/index.js
+++ b/index.js
@@ -181,7 +181,12 @@ app.use((req, res, next) => {
 
 // Serve static files separati per HTML e CSS (timing.html di default)
 app.use('/css', express.static(path.join(__dirname, 'css')));
-app.use(express.static(path.join(__dirname, 'html'), { index: 'timing.html' }));
+app.use(express.static(path.join(__dirname, 'html')));
+
+// Pagina principale
+app.get('/', (req, res) => {
+  res.sendFile(path.join(__dirname, 'html', 'timing.html'));
+});
 
 // --- API: elenco cronometri con logica nome/UUID/Sconosciuto ---
 app.get('/api/timings', (req, res) => {


### PR DESCRIPTION
## Summary
- serve timing.html explicitly on `/`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68850d4112f0832aaa019bb7b4b6aa0a