### PR TITLE
Add Docker compose support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:18-alpine
+WORKDIR /usr/src/app
+COPY package*.json ./
+RUN npm install --production
+COPY . .
+EXPOSE 3000
+CMD ["node", "index.js"]

--- a/README.md
+++ b/README.md
@@ -16,6 +16,19 @@ Applicazione Node.js per gestire un semplice sistema di cronometraggio tramite M
    ```
 5. Visita `http://localhost:3000/` (o la porta configurata) per la schermata dei tempi. La pagina di setup si trova a `/setup.html` e richiede autenticazione.
 
+## Avvio con Docker Compose
+
+Per eseguire l'applicazione in container è presente un `docker-compose.yml`.
+Da terminale avvia:
+
+```bash
+docker-compose up --build
+```
+
+La porta `3000` sarà esposta e le cartelle `config` e `data` verranno
+montate come volumi per permettere la personalizzazione delle impostazioni e
+la persistenza dei database.
+
 ## Struttura cartelle
 
 - **html/** contiene i file HTML (`timing.html` e `setup.html`).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3.8'
+services:
+  app:
+    build: .
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./config:/usr/src/app/config
+      - ./data:/usr/src/app/data


### PR DESCRIPTION
## Summary
- create Dockerfile for Node service
- add docker-compose.yml with bind mounts
- document container usage in README

## Testing
- `npm install`
- `npm test` *(fails: "Error: no test specified")*

------
https://chatgpt.com/codex/tasks/task_e_688540cb60cc832ab069c76bfedc1f75