### PR TITLE
Revamp admin navigation and event management

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -251,10 +251,10 @@ button:hover { background: var(--nav-hover); }
 
 .event-highlight {
   display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  flex-wrap: wrap;
+  flex-direction: column;
+  align-items: center;
   gap: 1rem;
+  text-align: center;
 }
 
 .current-info h3 {
@@ -265,11 +265,16 @@ button:hover { background: var(--nav-hover); }
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
+  justify-content: center;
 }
 
-.events-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+.event-actions.centered {
+  justify-content: center;
+}
+
+.events-list {
+  display: flex;
+  flex-direction: column;
   gap: 1rem;
 }
 
@@ -281,6 +286,11 @@ button:hover { background: var(--nav-hover); }
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
+}
+
+.event-card.active {
+  border-color: var(--button-bg);
+  box-shadow: 0 0 12px rgba(25, 118, 210, 0.2);
 }
 
 .event-card-header {
@@ -296,16 +306,44 @@ button:hover { background: var(--nav-hover); }
   font-size: 0.85rem;
 }
 
+.admin-create {
+  text-align: center;
+}
+
+.admin-section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.ghost-button {
+  background: transparent;
+  color: var(--button-bg);
+  border: 1px solid var(--button-bg);
+}
+
+.ghost-button:hover {
+  background: var(--button-bg);
+  color: var(--button-text);
+}
+
 .next-start {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
-  align-items: flex-start;
+  align-items: center;
+  text-align: center;
 }
 
 .next-start-value {
   font-size: 2.5rem;
   font-weight: bold;
+}
+
+.race-summary {
+  text-align: center;
 }
 
 .race-options {
@@ -318,10 +356,78 @@ button:hover { background: var(--nav-hover); }
   margin-top: 0;
 }
 
+.toggle-control {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+}
+
+.switch {
+  position: relative;
+  display: inline-block;
+  width: 48px;
+  height: 24px;
+}
+
+.switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: #bdbdbd;
+  transition: 0.3s;
+  border-radius: 24px;
+}
+
+.slider:before {
+  position: absolute;
+  content: '';
+  height: 20px;
+  width: 20px;
+  left: 2px;
+  bottom: 2px;
+  background-color: #ffffff;
+  transition: 0.3s;
+  border-radius: 50%;
+}
+
+.switch input:checked + .slider {
+  background-color: var(--button-bg);
+}
+
+.switch input:checked + .slider:before {
+  transform: translateX(24px);
+}
+
 .override-box, .pointer-box {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
+}
+
+.override-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.help-text {
+  font-size: 0.9rem;
+  color: rgba(0, 0, 0, 0.6);
+}
+
+body.dark-mode .help-text {
+  color: rgba(255, 255, 255, 0.6);
 }
 
 .participants-header {
@@ -399,6 +505,30 @@ button:hover { background: var(--nav-hover); }
 .heat-card.active {
   border-color: var(--button-bg);
   box-shadow: 0 0 10px rgba(25, 118, 210, 0.25);
+}
+
+.heat-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.timings-actions {
+  margin-top: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.timings-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.dnf {
+  color: #d32f2f;
+  font-weight: 600;
 }
 
 .heat-section {

--- a/html/admin.html
+++ b/html/admin.html
@@ -10,8 +10,7 @@
   <header class="navbar">
     <div class="navbar-left">Cesana Timing</div>
     <div class="navbar-right">
-      <a href="/timing.html" class="nav-link">Tempi</a>
-      <a href="/setup.html" class="nav-link">Setup</a>
+      <a href="/live" class="nav-link">Tempi</a>
       <a href="/admin" class="nav-link active">Admin</a>
       <button id="theme-toggle" class="theme-toggle">🌙</button>
     </div>
@@ -25,8 +24,16 @@
       </div>
     </section>
 
-    <section class="status-section">
-      <h2>Status Cronometro</h2>
+    <section class="admin-section admin-create">
+      <h2>Nuovo evento</h2>
+      <div class="event-actions centered">
+        <button id="create-training">Crea allenamento</button>
+        <button id="create-race">Crea gara</button>
+      </div>
+    </section>
+
+    <section class="admin-section status-section">
+      <h2>Status cronometro</h2>
       <div class="status-item">
         <div id="start-dot" class="status-dot status-offline"></div>
         <span>Start Gate: <span id="start-text">Offline</span></span>
@@ -38,16 +45,11 @@
     </section>
 
     <section class="admin-section">
-      <h2>Nuovo evento</h2>
-      <div class="event-actions">
-        <button id="create-training">Crea allenamento</button>
-        <button id="create-race">Crea gara</button>
+      <div class="admin-section-header">
+        <h2>Eventi</h2>
+        <button id="refresh-events" class="ghost-button">Aggiorna</button>
       </div>
-    </section>
-
-    <section class="admin-section">
-      <h2>Eventi</h2>
-      <div id="events-list" class="events-grid"></div>
+      <div id="events-list" class="events-list"></div>
     </section>
   </main>
 
@@ -68,16 +70,20 @@
   <script>
     const toggle = document.getElementById('theme-toggle');
     const currentTheme = localStorage.getItem('theme') || 'light';
-    document.body.classList.toggle('dark-mode', currentTheme==='dark');
-    toggle.textContent = currentTheme==='dark'?'☀️':'🌙';
+    document.body.classList.toggle('dark-mode', currentTheme === 'dark');
+    toggle.textContent = currentTheme === 'dark' ? '☀️' : '🌙';
     toggle.addEventListener('click', () => {
       const isDark = document.body.classList.toggle('dark-mode');
-      localStorage.setItem('theme', isDark?'dark':'light');
-      toggle.textContent = isDark?'☀️':'🌙';
+      localStorage.setItem('theme', isDark ? 'dark' : 'light');
+      toggle.textContent = isDark ? '☀️' : '🌙';
     });
 
+    const state = {
+      events: []
+    };
+
     function formatDate(value) {
-      if (!value) return '';
+      if (!value) return '—';
       const d = new Date(value);
       return d.toLocaleString('it-IT');
     }
@@ -86,21 +92,46 @@
       return event.type === 'race' ? 'Gara' : 'Allenamento';
     }
 
-    function buildPath(event, kind = 'view') {
-      if (!event) return '#';
-      if (event.type === 'race') {
-        return kind === 'manage' ? `/gara/${event.slug.split('/')[1]}/manage` : `/gara/${event.slug.split('/')[1]}`;
+    function formatStartMode(mode) {
+      if (!mode) return '—';
+      return mode === 'bib' ? 'Pettorale' : 'Braccialetto';
+    }
+
+    function formatOrder(order) {
+      if (!order) return '—';
+      return order === 'reverse' ? 'Invertito' : 'Normale';
+    }
+
+    function translateStatus(status) {
+      if (status === 'active') return 'Attivo';
+      if (status === 'completed') return 'Completato';
+      return status || '—';
+    }
+
+    function eventPaths(event) {
+      const code = event.slug?.split('/')[1];
+      if (!code) {
+        return { manage: '#', live: '#' };
       }
-      return `/allenamento/${event.slug.split('/')[1]}`;
+      if (event.type === 'race') {
+        return {
+          manage: `/gara/${code}/manage`,
+          live: `/gara/${code}`
+        };
+      }
+      return {
+        manage: `/allenamento/${code}/manage`,
+        live: `/allenamento/${code}`
+      };
     }
 
     async function loadStatus() {
       try {
         const res = await fetch('/api/status');
         const { startGate, stopGate } = await res.json();
-        document.getElementById('start-dot').className = `status-dot ${startGate?'status-online':'status-offline'}`;
+        document.getElementById('start-dot').className = `status-dot ${startGate ? 'status-online' : 'status-offline'}`;
         document.getElementById('start-text').textContent = startGate ? 'Online' : 'Offline';
-        document.getElementById('stop-dot').className = `status-dot ${stopGate?'status-online':'status-offline'}`;
+        document.getElementById('stop-dot').className = `status-dot ${stopGate ? 'status-online' : 'status-offline'}`;
         document.getElementById('stop-text').textContent = stopGate ? 'Online' : 'Offline';
       } catch (err) {
         console.error('Errore status:', err);
@@ -135,20 +166,35 @@
       }
       const info = document.createElement('div');
       info.className = 'current-info';
+      const typeLabel = describeType(event);
+      const code = event.slug?.split('/')[1] || '';
       info.innerHTML = `
-        <h3>${describeType(event)} ${event.slug.split('/')[1]}${event.name ? ' – ' + event.name : ''}</h3>
-        <p>Tempi registrati: <strong>${event.timings_count}</strong> | Partecipanti: <strong>${event.participants_count}</strong></p>
-        <p>Modalità partenza: <strong>${event.start_mode || '—'}</strong> | Ordine: <strong>${event.start_order || 'normal'}</strong></p>
+        <h3>${typeLabel} ${code}${event.name ? ' – ' + event.name : ''}</h3>
+        <p>Tempi registrati: <strong>${event.timings_count}</strong> · Partecipanti: <strong>${event.participants_count}</strong></p>
+        ${event.type === 'race' ? `<p>Modalità partenza: <strong>${formatStartMode(event.start_mode)}</strong> · Ordine: <strong>${formatOrder(event.start_order)}</strong></p>` : ''}
         <p>Creato: ${formatDate(event.created_at)}</p>
       `;
       const actions = document.createElement('div');
       actions.className = 'event-actions';
-      const openBtn = document.createElement('button');
-      openBtn.textContent = 'Apri pagina';
-      openBtn.addEventListener('click', () => {
-        const target = event.type === 'race' ? buildPath(event, 'manage') : buildPath(event);
-        window.location.href = target;
+      const paths = eventPaths(event);
+
+      const manageBtn = document.createElement('button');
+      manageBtn.textContent = 'Gestisci evento';
+      manageBtn.addEventListener('click', () => {
+        window.location.href = paths.manage;
       });
+
+      const liveBtn = document.createElement('button');
+      liveBtn.textContent = 'Apri live';
+      liveBtn.addEventListener('click', () => {
+        window.open(paths.live, '_blank');
+      });
+
+      const renameBtn = document.createElement('button');
+      renameBtn.className = 'ghost-button';
+      renameBtn.textContent = 'Rinomina';
+      renameBtn.addEventListener('click', () => renameEvent(event));
+
       const closeBtn = document.createElement('button');
       closeBtn.textContent = 'Chiudi evento';
       closeBtn.addEventListener('click', async () => {
@@ -156,59 +202,79 @@
         await fetch(`/api/events/${event.id}/close`, { method: 'POST' });
         await loadEvents();
       });
-      actions.append(openBtn, closeBtn);
+
+      actions.append(manageBtn, liveBtn, renameBtn, closeBtn);
       container.append(info, actions);
     }
 
+    function buildCardActions(cardActions, event) {
+      const paths = eventPaths(event);
+
+      if (event.is_active) {
+        const manage = document.createElement('button');
+        manage.textContent = 'Gestisci evento';
+        manage.addEventListener('click', () => { window.location.href = paths.manage; });
+
+        const live = document.createElement('button');
+        live.textContent = 'Apri live';
+        live.addEventListener('click', () => { window.open(paths.live, '_blank'); });
+
+        const rename = document.createElement('button');
+        rename.className = 'ghost-button';
+        rename.textContent = 'Rinomina';
+        rename.addEventListener('click', () => renameEvent(event));
+
+        const close = document.createElement('button');
+        close.textContent = 'Chiudi evento';
+        close.addEventListener('click', async () => {
+          if (!confirm('Chiudere questo evento?')) return;
+          await fetch(`/api/events/${event.id}/close`, { method: 'POST' });
+          await loadEvents();
+        });
+
+        cardActions.append(manage, live, rename, close);
+        return;
+      }
+
+      const live = document.createElement('button');
+      live.textContent = 'Apri live';
+      live.addEventListener('click', () => { window.open(paths.live, '_blank'); });
+
+      const rename = document.createElement('button');
+      rename.className = 'ghost-button';
+      rename.textContent = 'Rinomina';
+      rename.addEventListener('click', () => renameEvent(event));
+
+      const remove = document.createElement('button');
+      remove.textContent = 'Cancella';
+      remove.addEventListener('click', () => deleteEvent(event));
+
+      cardActions.append(live, rename, remove);
+    }
+
     function renderEvents(events) {
-      const grid = document.getElementById('events-list');
-      grid.innerHTML = '';
+      const list = document.getElementById('events-list');
+      list.innerHTML = '';
       if (!events.length) {
-        grid.innerHTML = '<p>Nessun evento registrato.</p>';
+        list.innerHTML = '<p>Nessun evento registrato.</p>';
         return;
       }
       events.forEach(event => {
-        const tpl = document.getElementById('event-card-template');
-        const card = tpl.content.firstElementChild.cloneNode(true);
-        card.querySelector('.event-title').textContent = `${describeType(event)} ${event.slug.split('/')[1]}`;
+        const template = document.getElementById('event-card-template');
+        const card = template.content.firstElementChild.cloneNode(true);
+        const code = event.slug?.split('/')[1] || '';
+        card.querySelector('.event-title').textContent = `${describeType(event)} ${code}`;
         card.querySelector('.event-subtitle').textContent = event.name || '—';
-        card.querySelector('.event-status').textContent = event.status;
+        card.querySelector('.event-status').textContent = translateStatus(event.status);
         card.querySelector('.event-meta').innerHTML = `
-          <p>Tempi: <strong>${event.timings_count}</strong> | Partecipanti: <strong>${event.participants_count}</strong></p>
+          <p>Tempi: <strong>${event.timings_count}</strong> · Partecipanti: <strong>${event.participants_count}</strong></p>
           <p>Creato: ${formatDate(event.created_at)}</p>
         `;
-        const actions = card.querySelector('.event-actions');
-        const openBtn = document.createElement('button');
-        openBtn.textContent = event.type === 'race' ? 'Gestisci' : 'Apri';
-        openBtn.addEventListener('click', () => {
-          const target = event.type === 'race' ? buildPath(event, 'manage') : buildPath(event);
-          window.location.href = target;
-        });
-        const liveBtn = document.createElement('button');
-        liveBtn.textContent = 'Live';
-        liveBtn.addEventListener('click', () => {
-          const target = event.type === 'race' ? `/gara/${event.slug.split('/')[1]}` : buildPath(event);
-          window.open(target, '_blank');
-        });
-        actions.append(openBtn, liveBtn);
-        if (!event.is_active) {
-          const activateBtn = document.createElement('button');
-          activateBtn.textContent = 'Attiva';
-          activateBtn.addEventListener('click', async () => {
-            await fetch(`/api/events/${event.id}/activate`, { method: 'POST' });
-            await loadEvents();
-          });
-          actions.append(activateBtn);
-        } else {
-          const closeBtn = document.createElement('button');
-          closeBtn.textContent = 'Chiudi';
-          closeBtn.addEventListener('click', async () => {
-            await fetch(`/api/events/${event.id}/close`, { method: 'POST' });
-            await loadEvents();
-          });
-          actions.append(closeBtn);
+        if (event.is_active) {
+          card.classList.add('active');
         }
-        grid.appendChild(card);
+        buildCardActions(card.querySelector('.event-actions'), event);
+        list.appendChild(card);
       });
     }
 
@@ -216,7 +282,9 @@
       try {
         const res = await fetch('/api/events');
         const events = await res.json();
-        const current = events.find(e => e.is_active);
+        events.sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
+        state.events = events;
+        const current = events.find(e => e.is_active) || null;
         renderCurrent(current);
         renderEvents(events);
       } catch (err) {
@@ -224,8 +292,42 @@
       }
     }
 
+    async function renameEvent(event) {
+      const currentName = event.name || '';
+      const value = prompt('Nuovo nome evento (lascia vuoto per nessun nome)', currentName);
+      if (value === null) return;
+      const trimmed = value.trim();
+      try {
+        const res = await fetch(`/api/events/${event.id}`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ name: trimmed || null })
+        });
+        if (!res.ok) {
+          throw new Error('rename-failed');
+        }
+        await loadEvents();
+      } catch (err) {
+        alert('Errore durante la rinomina');
+      }
+    }
+
+    async function deleteEvent(event) {
+      if (!confirm(`Cancellare definitivamente ${describeType(event)} ${event.slug}?`)) return;
+      try {
+        const res = await fetch(`/api/events/${event.id}`, { method: 'DELETE' });
+        if (!res.ok) {
+          throw new Error('delete-failed');
+        }
+        await loadEvents();
+      } catch (err) {
+        alert('Errore durante la cancellazione');
+      }
+    }
+
     document.getElementById('create-training').addEventListener('click', () => createEvent('training'));
     document.getElementById('create-race').addEventListener('click', () => createEvent('race'));
+    document.getElementById('refresh-events').addEventListener('click', loadEvents);
 
     loadStatus();
     loadEvents();

--- a/html/race-view.html
+++ b/html/race-view.html
@@ -10,8 +10,7 @@
   <header class="navbar">
     <div class="navbar-left">Cesana Timing</div>
     <div class="navbar-right">
-      <a href="/timing.html" class="nav-link">Tempi</a>
-      <a href="/setup.html" class="nav-link">Setup</a>
+      <a href="/live" class="nav-link">Tempi</a>
       <a href="/admin" class="nav-link">Admin</a>
       <button id="theme-toggle" class="theme-toggle">🌙</button>
     </div>
@@ -102,9 +101,10 @@
         const tbody = table.querySelector('tbody');
         rows.forEach(r => {
           const tr = document.createElement('tr');
+          const timeHtml = r.status === 'dnf' ? '<span class="dnf">DNF</span>' : r.elapsed;
           tr.innerHTML = `
             <td>${r.best ? '☆ ' : ''}${r.name}</td>
-            <td>${r.elapsed}</td>
+            <td>${timeHtml}</td>
             <td class="start-time-col">${r.start_time}</td>
           `;
           if (r.color) {

--- a/html/setup.html
+++ b/html/setup.html
@@ -10,9 +10,8 @@
     <header class="navbar">
     <div class="navbar-left">Cesana Timing</div>
     <div class="navbar-right">
-      <a href="/timing.html" class="nav-link">Tempi</a>
-      <a href="/setup.html" class="nav-link active">Setup</a>
-      <a href="/admin" class="nav-link">Admin</a>
+      <a href="/live" class="nav-link">Tempi</a>
+      <a href="/admin" class="nav-link active">Admin</a>
       <button id="theme-toggle" class="theme-toggle">🌙</button>
     </div>
   </header>

--- a/html/timing.html
+++ b/html/timing.html
@@ -10,8 +10,7 @@
     <header class="navbar">
     <div class="navbar-left">Cesana Timing</div>
     <div class="navbar-right">
-      <a href="/timing.html" class="nav-link active">Tempi</a>
-      <a href="/setup.html" class="nav-link">Setup</a>
+      <a href="/live" class="nav-link active">Tempi</a>
       <a href="/admin" class="nav-link">Admin</a>
       <button id="theme-toggle" class="theme-toggle">🌙</button>
     </div>
@@ -62,9 +61,10 @@
       tbody.innerHTML = '';
       data.forEach(r => {
         const tr = document.createElement('tr');
+        const timeHtml = r.status === 'dnf' ? '<span class="dnf">DNF</span>' : r.elapsed;
         tr.innerHTML = `
           <td>${r.best ? '☆ ' : ''}${r.name}</td>
-          <td>${r.elapsed}</td>
+          <td>${timeHtml}</td>
           <td class="start-time-col">${r.start_time}</td>
         `;
         if (r.color) {

--- a/html/training-manage.html
+++ b/html/training-manage.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Gestione Gara - Cesana Timing</title>
+  <title>Gestione Allenamento - Cesana Timing</title>
   <link rel="stylesheet" href="/css/style.css">
 </head>
 <body>
@@ -18,48 +18,8 @@
 
   <main class="container race-manage">
     <section class="race-section race-summary">
-      <h1 id="race-title">Gestione Gara</h1>
-      <p id="race-info">Caricamento…</p>
-      <div class="next-start">
-        <h2>Prossima partenza</h2>
-        <div id="next-start-value" class="next-start-value">—</div>
-      </div>
-    </section>
-
-    <section class="race-section">
-      <h2>Opzioni di gara</h2>
-      <div class="race-options">
-        <div class="toggle-control">
-          <span>Braccialetto</span>
-          <label class="switch">
-            <input type="checkbox" id="start-mode-toggle">
-            <span class="slider"></span>
-          </label>
-          <span>Pettorale</span>
-        </div>
-        <div class="toggle-control">
-          <span>Normale</span>
-          <label class="switch">
-            <input type="checkbox" id="start-order-toggle">
-            <span class="slider"></span>
-          </label>
-          <span>Invertito</span>
-        </div>
-        <div class="override-box">
-          <h3>Sovrascrivi partenza</h3>
-          <input type="number" id="override-input" placeholder="Numero pettorale">
-          <div class="override-actions">
-            <button id="override-btn">Imposta</button>
-            <button id="clear-override" class="ghost-button">Annulla</button>
-          </div>
-        </div>
-        <div class="pointer-box">
-          <h3>Indice partenza</h3>
-          <p id="pointer-info">—</p>
-          <p class="help-text">Indica la posizione corrente nella lista di partenza.</p>
-          <button id="reset-pointer" class="ghost-button">Reset ordine</button>
-        </div>
-      </div>
+      <h1 id="training-title">Gestione Allenamento</h1>
+      <p id="training-info">Caricamento…</p>
     </section>
 
     <section class="race-section">
@@ -136,48 +96,12 @@
       return `${parts[0]}/${parts[1]}`;
     }
 
-    function sortParticipants(startOrder) {
-      const apripista = state.participants.find(p => p.bib_number === 0);
-      const others = state.participants
-        .filter(p => p.bib_number != null && p.bib_number !== 0)
-        .sort((a, b) => (a.bib_number || 0) - (b.bib_number || 0));
-      if (startOrder === 'reverse') {
-        others.reverse();
-      }
-      const queue = [];
-      if (apripista) queue.push(apripista);
-      queue.push(...others);
-      return queue;
-    }
-
-    function parseMetadata(meta) {
-      if (!meta) return {};
-      try { return JSON.parse(meta); } catch { return {}; }
-    }
-
-    function computeNextStart() {
-      if (!state.event) return '—';
-      const metadata = parseMetadata(state.event.metadata);
-      if (metadata.overrideBib != null) {
-        return metadata.overrideBib;
-      }
-      const queue = sortParticipants(state.event.start_order || 'normal');
-      if (!queue.length) return '—';
-      const pointer = state.event.next_pointer || 0;
-      if (pointer >= queue.length) return queue[queue.length - 1].bib_number ?? '—';
-      return queue[pointer].bib_number ?? '—';
-    }
-
     function renderInfo() {
       if (!state.event) return;
-      document.getElementById('race-title').textContent = `${state.event.name || 'Gara'} (${state.event.slug})`;
-      document.getElementById('race-info').innerHTML = `
+      document.getElementById('training-title').textContent = `${state.event.name || 'Allenamento'} (${state.event.slug})`;
+      document.getElementById('training-info').innerHTML = `
         Stato: <strong>${state.event.status}</strong> · Tempi: <strong>${state.event.timings_count}</strong> · Partecipanti: <strong>${state.event.participants_count}</strong>
       `;
-      document.getElementById('next-start-value').textContent = computeNextStart();
-      document.getElementById('pointer-info').textContent = `Indice corrente: ${state.event.next_pointer || 0}`;
-      document.getElementById('start-mode-toggle').checked = (state.event.start_mode || 'bracelet') === 'bib';
-      document.getElementById('start-order-toggle').checked = (state.event.start_order || 'normal') === 'reverse';
       const total = state.participants.filter(p => p.bib_number != null && p.bib_number !== 0).length;
       const totalInput = document.getElementById('participants-total');
       if (document.activeElement !== totalInput) {
@@ -231,6 +155,8 @@
         if (state.event.current_heat_id === heat.id) {
           div.classList.add('active');
         }
+        const title = document.createElement('span');
+        title.textContent = heat.name;
         const actions = document.createElement('div');
         actions.className = 'heat-actions';
         const renameBtn = document.createElement('button');
@@ -241,8 +167,6 @@
         setBtn.textContent = 'Attiva';
         setBtn.dataset.heat = heat.id;
         actions.append(renameBtn, setBtn);
-        const title = document.createElement('span');
-        title.textContent = heat.name;
         div.append(title, actions);
         container.appendChild(div);
       });
@@ -281,7 +205,7 @@
       try {
         const lookup = await fetch(`/api/events/lookup?slug=${encodeURIComponent(slug)}`);
         if (!lookup.ok) {
-          document.getElementById('race-info').textContent = 'Evento non trovato';
+          document.getElementById('training-info').textContent = 'Evento non trovato';
           return;
         }
         const base = await lookup.json();
@@ -294,7 +218,7 @@
         renderParticipants();
         renderHeats();
       } catch (err) {
-        console.error('Errore caricamento gara', err);
+        console.error('Errore caricamento allenamento', err);
       }
     }
 
@@ -385,28 +309,6 @@
       loadData();
     }
 
-    document.getElementById('start-mode-toggle').addEventListener('change', async (e) => {
-      if (!state.event) return;
-      const mode = e.target.checked ? 'bib' : 'bracelet';
-      await fetch(`/api/events/${state.event.id}/config`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ start_mode: mode })
-      });
-      loadData();
-    });
-
-    document.getElementById('start-order-toggle').addEventListener('change', async (e) => {
-      if (!state.event) return;
-      const order = e.target.checked ? 'reverse' : 'normal';
-      await fetch(`/api/events/${state.event.id}/config`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ start_order: order })
-      });
-      loadData();
-    });
-
     document.getElementById('reset-participants').addEventListener('click', async () => {
       if (!state.event) return;
       const total = Number(document.getElementById('participants-total').value || 0);
@@ -414,37 +316,6 @@
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ total })
-      });
-      loadData();
-    });
-
-    document.getElementById('override-btn').addEventListener('click', async () => {
-      if (!state.event) return;
-      const value = document.getElementById('override-input').value;
-      await fetch(`/api/events/${state.event.id}/override`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ bibNumber: value })
-      });
-      loadData();
-    });
-
-    document.getElementById('clear-override').addEventListener('click', async () => {
-      if (!state.event) return;
-      await fetch(`/api/events/${state.event.id}/override`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ bibNumber: null })
-      });
-      loadData();
-    });
-
-    document.getElementById('reset-pointer').addEventListener('click', async () => {
-      if (!state.event) return;
-      await fetch(`/api/events/${state.event.id}/pointer`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ pointer: 0 })
       });
       loadData();
     });

--- a/html/training.html
+++ b/html/training.html
@@ -10,8 +10,7 @@
   <header class="navbar">
     <div class="navbar-left">Cesana Timing</div>
     <div class="navbar-right">
-      <a href="/timing.html" class="nav-link">Tempi</a>
-      <a href="/setup.html" class="nav-link">Setup</a>
+      <a href="/live" class="nav-link">Tempi</a>
       <a href="/admin" class="nav-link">Admin</a>
       <button id="theme-toggle" class="theme-toggle">🌙</button>
     </div>
@@ -94,9 +93,10 @@
       }
       data.forEach(r => {
         const tr = document.createElement('tr');
+        const timeHtml = r.status === 'dnf' ? '<span class="dnf">DNF</span>' : r.elapsed;
         tr.innerHTML = `
           <td>${r.best ? '☆ ' : ''}${r.name}</td>
-          <td>${r.elapsed}</td>
+          <td>${timeHtml}</td>
           <td class="start-time-col">${r.start_time}</td>
         `;
         if (r.color) {

--- a/src/db/index.js
+++ b/src/db/index.js
@@ -45,6 +45,7 @@ function initializeTimingDb() {
     addColumn(timingDb, 'timings', 'heat_id INTEGER');
     addColumn(timingDb, 'timings', 'heat_name TEXT');
     addColumn(timingDb, 'timings', 'lap INTEGER DEFAULT 1');
+    addColumn(timingDb, 'timings', "status TEXT NOT NULL DEFAULT 'completed'");
 
     timingDb.run(`
       CREATE TABLE IF NOT EXISTS events (

--- a/src/mqtt/index.js
+++ b/src/mqtt/index.js
@@ -15,6 +15,30 @@ let lastStartRaw = null;
 let lastStartDate = null;
 let lastContext = null;
 
+async function recordPendingDnf() {
+  if (!lastStartDate || !lastStartRaw || !lastContext) {
+    return;
+  }
+  if (lastContext.eventType !== 'race' || !lastContext.eventId) {
+    return;
+  }
+  try {
+    await recordTiming({
+      tagId: lastContext.tagId,
+      startTime: lastStartRaw,
+      elapsedMs: 0,
+      eventId: lastContext.eventId,
+      participantId: lastContext.participantId,
+      bibNumber: lastContext.bibNumber,
+      heatId: lastContext.heatId,
+      heatName: lastContext.heatName,
+      status: 'dnf'
+    });
+  } catch (err) {
+    console.error('[ERROR] record DNF:', err.message);
+  }
+}
+
 function parseTimePayload(payload) {
   const [h = 0, m = 0, s = 0, cs = 0] = payload.split(/[:.]/).map(Number);
   const baseDate = new Date();
@@ -23,6 +47,7 @@ function parseTimePayload(payload) {
 }
 
 async function handleStart(payload) {
+  await recordPendingDnf();
   lastStartRaw = payload;
   lastStartDate = parseTimePayload(payload);
   const activeEvent = await getActiveEvent();
@@ -32,7 +57,8 @@ async function handleStart(payload) {
     participantId: null,
     bibNumber: null,
     heatId: activeEvent?.current_heat_id || null,
-    heatName: null
+    heatName: null,
+    eventType: activeEvent?.type || null
   };
 
   if (activeEvent?.current_heat_id) {
@@ -74,7 +100,8 @@ async function handleStop(payload) {
     participantId: null,
     bibNumber: null,
     heatId: null,
-    heatName: null
+    heatName: null,
+    eventType: null
   };
 
   try {
@@ -86,7 +113,8 @@ async function handleStop(payload) {
       participantId: context.participantId,
       bibNumber: context.bibNumber,
       heatId: context.heatId,
-      heatName: context.heatName
+      heatName: context.heatName,
+      status: 'completed'
     });
   } catch (err) {
     console.error('[ERROR] insert timing:', err.message);

--- a/src/services/eventService.js
+++ b/src/services/eventService.js
@@ -81,12 +81,32 @@ async function nextSequence(type) {
   return row?.seq || 1;
 }
 
+async function completeOtherEvents(exceptId = null) {
+  const now = new Date().toISOString();
+  const params = [now, now];
+  let where = 'WHERE (status = \"active\" OR is_active = 1)';
+  if (exceptId != null) {
+    where += ' AND id != ?';
+    params.push(exceptId);
+  }
+  await run(
+    timingDb,
+    `UPDATE events
+     SET is_active = 0,
+         status = 'completed',
+         ended_at = COALESCE(ended_at, ?),
+         updated_at = ?
+     ${where}`,
+    params
+  );
+}
+
 async function createEvent({ type, name }) {
   const sequence = await nextSequence(type);
   const code = buildCode(type, sequence);
   const now = new Date().toISOString();
 
-  await run(timingDb, `UPDATE events SET is_active = 0 WHERE is_active = 1`);
+  await completeOtherEvents();
 
   const result = await run(
     timingDb,
@@ -161,7 +181,7 @@ async function getActiveEvent() {
 
 async function setActiveEvent(id) {
   const now = new Date().toISOString();
-  await run(timingDb, `UPDATE events SET is_active = 0 WHERE is_active = 1`);
+  await completeOtherEvents(id);
   await run(
     timingDb,
     `UPDATE events SET is_active = 1, status = 'active', updated_at = ?, started_at = COALESCE(started_at, ?) WHERE id = ?`,
@@ -209,6 +229,33 @@ async function updateEventConfig(id, config) {
     params
   );
   return getEventById(id);
+}
+
+async function updateEventName(id, name) {
+  const now = new Date().toISOString();
+  await run(
+    timingDb,
+    `UPDATE events SET name = ?, updated_at = ? WHERE id = ?`,
+    [name || null, now, id]
+  );
+  return getEventById(id);
+}
+
+async function renameHeat(eventId, heatId, name) {
+  if (!heatId) return null;
+  await run(
+    timingDb,
+    `UPDATE heats SET name = ? WHERE id = ? AND event_id = ?`,
+    [name || null, heatId, eventId]
+  );
+  return get(timingDb, `SELECT * FROM heats WHERE id = ?`, [heatId]);
+}
+
+async function deleteEvent(id) {
+  await run(timingDb, `DELETE FROM timings WHERE event_id = ?`, [id]);
+  await run(timingDb, `DELETE FROM participants WHERE event_id = ?`, [id]);
+  await run(timingDb, `DELETE FROM heats WHERE event_id = ?`, [id]);
+  await run(timingDb, `DELETE FROM events WHERE id = ?`, [id]);
 }
 
 async function getHeatById(id) {
@@ -327,15 +374,18 @@ module.exports = {
   setActiveEvent,
   closeEvent,
   updateEventConfig,
+  updateEventName,
   listHeats,
   getHeatById,
   addHeat,
+  renameHeat,
   listParticipants,
   getParticipantByTag,
   getParticipantByBib,
   upsertParticipant,
   removeParticipant,
   resetParticipants,
+  deleteEvent,
   buildSlug,
   getEventBySlug,
   getEventByCode,

--- a/src/services/timingService.js
+++ b/src/services/timingService.js
@@ -39,11 +39,12 @@ async function recordTiming({
   bibNumber = null,
   heatId = null,
   heatName = null,
-  lap = 1
+  lap = 1,
+  status = 'completed'
 }) {
   await run(
-    `INSERT INTO timings(tag_id, start_time, elapsed_ms, event_id, participant_id, bib_number, heat_id, heat_name, lap)
-     VALUES(?,?,?,?,?,?,?,?,?)`,
+    `INSERT INTO timings(tag_id, start_time, elapsed_ms, event_id, participant_id, bib_number, heat_id, heat_name, lap, status)
+     VALUES(?,?,?,?,?,?,?,?,?,?)`,
     [
       tagId || 'Sconosciuto',
       startTime,
@@ -53,7 +54,8 @@ async function recordTiming({
       bibNumber,
       heatId,
       heatName,
-      lap
+      lap,
+      status
     ]
   );
 }
@@ -77,6 +79,7 @@ async function listTimings({ limit = 100, eventId = null } = {}) {
        t.bib_number,
        t.heat_id,
        t.heat_name,
+       t.status,
        assocdb.tags.name  AS tag_name,
        assocdb.tags.color AS tag_color
      FROM timings t
@@ -89,6 +92,7 @@ async function listTimings({ limit = 100, eventId = null } = {}) {
 
   const bestByUuid = {};
   rows.forEach(r => {
+    if (r.status === 'dnf') return;
     const key = r.tag_id || `bib:${r.bib_number || ''}`;
     if (!bestByUuid[key] || r.elapsed_ms < bestByUuid[key]) {
       bestByUuid[key] = r.elapsed_ms;
@@ -108,23 +112,26 @@ async function listTimings({ limit = 100, eventId = null } = {}) {
     } else {
       displayName = 'Sconosciuto';
     }
+    const key = r.tag_id || `bib:${r.bib_number || ''}`;
+    const isDnf = r.status === 'dnf';
     return {
       id: r.id,
       name: displayName,
       start_time: r.start_time,
-      elapsed: formatMs(r.elapsed_ms),
+      elapsed: isDnf ? 'DNF' : formatMs(r.elapsed_ms),
       created_at: r.created_at,
       color: r.tag_color,
-      best: r.elapsed_ms === bestByUuid[r.tag_id || `bib:${r.bib_number || ''}`],
+      best: !isDnf && bestByUuid[key] != null && r.elapsed_ms === bestByUuid[key],
       bib_number: r.bib_number,
-      heat_name: r.heat_name
+      heat_name: r.heat_name,
+      status: r.status
     };
   });
 }
 
 async function listRawTimings(eventId) {
   const rows = await all(
-    `SELECT id, tag_id, start_time, elapsed_ms, created_at, event_id, participant_id, bib_number, heat_id, heat_name
+    `SELECT id, tag_id, start_time, elapsed_ms, created_at, event_id, participant_id, bib_number, heat_id, heat_name, status
      FROM timings
      WHERE event_id = ?
      ORDER BY created_at ASC`,

--- a/src/web/app.js
+++ b/src/web/app.js
@@ -50,7 +50,7 @@ app.use('/api/events', eventsRouter);
 app.use('/api/unassigned', unassignedRouter);
 
 app.get('/', (req, res) => {
-  res.sendFile(path.join(__dirname, '..', '..', 'html', 'timing.html'));
+  res.redirect('/live');
 });
 
 app.get('/live', (req, res) => {
@@ -59,6 +59,10 @@ app.get('/live', (req, res) => {
 
 app.get('/admin', auth, (req, res) => {
   res.sendFile(path.join(__dirname, '..', '..', 'html', 'admin.html'));
+});
+
+app.get('/allenamento/:code/manage', auth, (req, res) => {
+  res.sendFile(path.join(__dirname, '..', '..', 'html', 'training-manage.html'));
 });
 
 app.get('/allenamento/:code', auth, (req, res) => {

--- a/src/web/routes/events.js
+++ b/src/web/routes/events.js
@@ -16,7 +16,10 @@ const {
   upsertParticipant,
   removeParticipant,
   resetParticipants,
-  setNextPointer
+  setNextPointer,
+  updateEventName,
+  renameHeat,
+  deleteEvent
 } = require('../../services/eventService');
 const { setOverrideBib } = require('../../services/raceLogic');
 const { listRawTimings, recordTiming, formatMs } = require('../../services/timingService');
@@ -81,6 +84,16 @@ router.post('/', async (req, res) => {
     }
     const event = await createEvent({ type, name });
     res.status(201).json(event);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+router.patch('/:id', async (req, res) => {
+  try {
+    const { name } = req.body;
+    const event = await updateEventName(Number(req.params.id), name);
+    res.json(event);
   } catch (err) {
     res.status(500).json({ error: err.message });
   }
@@ -152,6 +165,15 @@ router.post('/:id/heats', async (req, res) => {
   }
 });
 
+router.patch('/:id/heats/:heatId', async (req, res) => {
+  try {
+    const heat = await renameHeat(Number(req.params.id), Number(req.params.heatId), req.body.name);
+    res.json(heat);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
 router.get('/:id/export/participants', async (req, res) => {
   try {
     const participants = await listParticipants(Number(req.params.id));
@@ -173,13 +195,14 @@ router.get('/:id/export/timings', async (req, res) => {
       listParticipants(eventId)
     ]);
     const participantById = new Map(participants.map(p => [p.id, p]));
-    const header = toCsvRow(['bib_number', 'name', 'tag_id', 'elapsed_ms', 'elapsed_text', 'start_time']);
+    const header = toCsvRow(['bib_number', 'name', 'tag_id', 'elapsed_ms', 'elapsed_text', 'status', 'start_time']);
     const rows = timings.map(t => {
       const participant = t.participant_id ? participantById.get(t.participant_id) : null;
       const bib = participant?.bib_number ?? t.bib_number ?? '';
       const name = participant?.name || '';
       const tag = participant?.tag_uuid || t.tag_id || '';
-      return toCsvRow([bib, name, tag, t.elapsed_ms, formatMs(t.elapsed_ms), t.start_time]);
+      const elapsedText = t.status === 'dnf' ? 'DNF' : formatMs(t.elapsed_ms);
+      return toCsvRow([bib, name, tag, t.elapsed_ms, elapsedText, t.status, t.start_time]);
     });
     res.setHeader('Content-Type', 'text/csv; charset=utf-8');
     res.setHeader('Content-Disposition', 'attachment; filename="timings.csv"');
@@ -294,6 +317,15 @@ router.post('/:id/override', async (req, res) => {
     const bib = raw === undefined || raw === null || raw === '' ? null : Number(raw);
     const metadata = await setOverrideBib(Number(req.params.id), bib);
     res.json(metadata);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+router.delete('/:id', async (req, res) => {
+  try {
+    await deleteEvent(Number(req.params.id));
+    res.sendStatus(204);
   } catch (err) {
     res.status(500).json({ error: err.message });
   }


### PR DESCRIPTION
## Summary
- align all pages to the simplified `/live`/`/admin` navigation and refresh the admin dashboard with centered sections, quick actions, and refreshed styling
- overhaul the race management experience with toggle controls, organised import/export areas, heat rename actions, and add a dedicated training management page that mirrors the new tools
- track DNF results end-to-end by extending the MQTT handler, timing APIs, and CSV exports, while exposing rename/delete event APIs and updated live views

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cfda03582c832a85932fdbdca30441