### PR TITLE
Improve live view, rankings, and admin layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -348,12 +348,24 @@ button:hover { background: var(--nav-hover); }
 
 .race-options {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
   gap: 1rem;
 }
 
-.race-options h3 {
-  margin-top: 0;
+.option-card {
+  border: 1px solid var(--table-border);
+  border-radius: 0.5rem;
+  padding: 1rem;
+  background: var(--table-body-bg);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  align-items: center;
+  text-align: center;
+  width: 100%;
+}
+
+.option-card h3 {
+  margin: 0;
 }
 
 .toggle-control {
@@ -412,6 +424,12 @@ button:hover { background: var(--nav-hover); }
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
+  width: 100%;
+}
+
+.override-box input {
+  width: 100%;
+  margin: 0;
 }
 
 .override-actions {
@@ -454,10 +472,15 @@ body.dark-mode .help-text {
 .import-button {
   position: relative;
   overflow: hidden;
-  border: 1px dashed var(--table-border);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--button-bg);
+  color: var(--button-text);
   padding: 0.5rem 1rem;
   border-radius: 0.5rem;
   cursor: pointer;
+  font-weight: 500;
 }
 
 .import-button input {
@@ -473,10 +496,17 @@ body.dark-mode .help-text {
 .participants-table input {
   width: 100%;
   padding: 0.4rem;
+  margin: 0;
   border-radius: 0.4rem;
   border: 1px solid var(--table-border);
   background: var(--bg-color);
   color: var(--text-color);
+  max-width: 100%;
+}
+
+.participants-actions input {
+  margin: 0;
+  max-width: 100px;
 }
 
 .heats-header {
@@ -544,7 +574,18 @@ body.dark-mode .help-text {
     flex-direction: column;
     align-items: stretch;
   }
+}
+
+@media (min-width: 720px) {
   .race-options {
-    grid-template-columns: 1fr;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
+  .participants-actions {
+    flex-wrap: nowrap;
+  }
+}
+
+.event-info {
+  margin: 0.25rem 0 0.75rem;
+  font-style: italic;
 }

--- a/html/admin.html
+++ b/html/admin.html
@@ -11,6 +11,7 @@
     <div class="navbar-left">Cesana Timing</div>
     <div class="navbar-right">
       <a href="/live" class="nav-link">Tempi</a>
+      <a href="/classifiche" class="nav-link">Classifiche</a>
       <a href="/admin" class="nav-link active">Admin</a>
       <button id="theme-toggle" class="theme-toggle">🌙</button>
     </div>
@@ -185,13 +186,12 @@
       });
 
       const liveBtn = document.createElement('button');
-      liveBtn.textContent = 'Apri live';
+      liveBtn.textContent = event.status === 'active' ? 'Apri live' : 'Tempi';
       liveBtn.addEventListener('click', () => {
         window.open(paths.live, '_blank');
       });
 
       const renameBtn = document.createElement('button');
-      renameBtn.className = 'ghost-button';
       renameBtn.textContent = 'Rinomina';
       renameBtn.addEventListener('click', () => renameEvent(event));
 
@@ -220,7 +220,6 @@
         live.addEventListener('click', () => { window.open(paths.live, '_blank'); });
 
         const rename = document.createElement('button');
-        rename.className = 'ghost-button';
         rename.textContent = 'Rinomina';
         rename.addEventListener('click', () => renameEvent(event));
 
@@ -237,11 +236,10 @@
       }
 
       const live = document.createElement('button');
-      live.textContent = 'Apri live';
+      live.textContent = 'Tempi';
       live.addEventListener('click', () => { window.open(paths.live, '_blank'); });
 
       const rename = document.createElement('button');
-      rename.className = 'ghost-button';
       rename.textContent = 'Rinomina';
       rename.addEventListener('click', () => renameEvent(event));
 

--- a/html/classifiche.html
+++ b/html/classifiche.html
@@ -3,29 +3,29 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Tempi - Cesana Timing</title>
+  <title>Classifiche - Cesana Timing</title>
   <link rel="stylesheet" href="/css/style.css">
 </head>
 <body>
-    <header class="navbar">
+  <header class="navbar">
     <div class="navbar-left">Cesana Timing</div>
     <div class="navbar-right">
-      <a href="/live" class="nav-link active">Tempi</a>
-      <a href="/classifiche" class="nav-link">Classifiche</a>
+      <a href="/live" class="nav-link">Tempi</a>
+      <a href="/classifiche" class="nav-link active">Classifiche</a>
       <a href="/admin" class="nav-link">Admin</a>
       <button id="theme-toggle" class="theme-toggle">🌙</button>
     </div>
   </header>
 
   <main class="container">
-    <h1>Tempi Live</h1>
+    <h1>Classifiche</h1>
     <p id="event-info" class="event-info">Caricamento evento…</p>
     <table>
       <thead>
         <tr>
           <th>Nome/Tag</th>
           <th>Tempo</th>
-          <th class="start-time-col">Ora partenza</th>
+          <th>Distacco</th>
         </tr>
       </thead>
       <tbody id="tbody">
@@ -35,15 +35,14 @@
   </main>
 
   <script>
-    // Theme toggle
     const toggle = document.getElementById('theme-toggle');
     const currentTheme = localStorage.getItem('theme') || 'light';
-    document.body.classList.toggle('dark-mode', currentTheme==='dark');
-    toggle.textContent = currentTheme==='dark'?'☀️':'🌙';
+    document.body.classList.toggle('dark-mode', currentTheme === 'dark');
+    toggle.textContent = currentTheme === 'dark' ? '☀️' : '🌙';
     toggle.addEventListener('click', () => {
       const isDark = document.body.classList.toggle('dark-mode');
-      localStorage.setItem('theme', isDark?'dark':'light');
-      toggle.textContent = isDark?'☀️':'🌙';
+      localStorage.setItem('theme', isDark ? 'dark' : 'light');
+      toggle.textContent = isDark ? '☀️' : '🌙';
     });
 
     const tbody = document.getElementById('tbody');
@@ -57,6 +56,18 @@
       return `${typeLabel} ${code}${namePart}`;
     }
 
+    function formatDelta(ms) {
+      const abs = Math.max(ms, 0);
+      const minutes = Math.floor(abs / 60000);
+      const seconds = Math.floor((abs % 60000) / 1000);
+      const centiseconds = Math.floor((abs % 1000) / 10);
+      const pad = (value) => String(value).padStart(2, '0');
+      if (minutes > 0) {
+        return `+${minutes}:${pad(seconds)}.${pad(centiseconds)}`;
+      }
+      return `+${seconds}.${pad(centiseconds)}`;
+    }
+
     function renderNoEvent() {
       eventInfo.textContent = 'Nessun evento attivo.';
       tbody.innerHTML = '<tr><td colspan="3">Nessun tempo disponibile.</td></tr>';
@@ -68,13 +79,24 @@
         tbody.innerHTML = '<tr><td colspan="3">Nessun tempo registrato.</td></tr>';
         return;
       }
-      rows.forEach(row => {
+
+      const completed = rows.filter(row => row.status !== 'dnf').sort((a, b) => a.elapsed_ms - b.elapsed_ms);
+      const dnfs = rows.filter(row => row.status === 'dnf');
+      const bestTime = completed.length ? completed[0].elapsed_ms : null;
+      const ordered = [...completed, ...dnfs];
+
+      ordered.forEach(row => {
         const tr = document.createElement('tr');
         const timeHtml = row.status === 'dnf' ? '<span class="dnf">DNF</span>' : row.elapsed;
+        let gapHtml = '—';
+        if (row.status !== 'dnf' && bestTime != null) {
+          const delta = row.elapsed_ms - bestTime;
+          gapHtml = formatDelta(delta);
+        }
         tr.innerHTML = `
-          <td>${row.best ? '☆ ' : ''}${row.name}</td>
+          <td>${row.name}</td>
           <td>${timeHtml}</td>
-          <td class="start-time-col">${row.start_time}</td>
+          <td>${gapHtml}</td>
         `;
         tbody.appendChild(tr);
       });
@@ -93,21 +115,21 @@
         const event = await eventRes.json();
         eventInfo.textContent = `${describeEvent(event)} · Stato ${event.status}`;
 
-        const res = await fetch(`/api/timings?eventId=${event.id}&limit=200`);
+        const res = await fetch(`/api/timings?eventId=${event.id}&limit=500`);
         if (!res.ok) {
           throw new Error('timing-load');
         }
         const data = await res.json();
         renderTimings(data);
       } catch (err) {
-        console.error('Errore caricamento live', err);
+        console.error('Errore caricamento classifiche', err);
         eventInfo.textContent = 'Errore durante il caricamento.';
         tbody.innerHTML = '<tr><td colspan="3">—</td></tr>';
       }
     }
 
     loadData();
-    setInterval(loadData, 1000);
+    setInterval(loadData, 2000);
   </script>
 </body>
 </html>

--- a/html/race-manage.html
+++ b/html/race-manage.html
@@ -11,6 +11,7 @@
     <div class="navbar-left">Cesana Timing</div>
     <div class="navbar-right">
       <a href="/live" class="nav-link">Tempi</a>
+      <a href="/classifiche" class="nav-link">Classifiche</a>
       <a href="/admin" class="nav-link active">Admin</a>
       <button id="theme-toggle" class="theme-toggle">🌙</button>
     </div>
@@ -29,23 +30,29 @@
     <section class="race-section">
       <h2>Opzioni di gara</h2>
       <div class="race-options">
-        <div class="toggle-control">
-          <span>Braccialetto</span>
-          <label class="switch">
-            <input type="checkbox" id="start-mode-toggle">
-            <span class="slider"></span>
-          </label>
-          <span>Pettorale</span>
+        <div class="option-card">
+          <h3>Modalità partenza</h3>
+          <div class="toggle-control">
+            <span>Braccialetto</span>
+            <label class="switch">
+              <input type="checkbox" id="start-mode-toggle">
+              <span class="slider"></span>
+            </label>
+            <span>Pettorale</span>
+          </div>
         </div>
-        <div class="toggle-control">
-          <span>Normale</span>
-          <label class="switch">
-            <input type="checkbox" id="start-order-toggle">
-            <span class="slider"></span>
-          </label>
-          <span>Invertito</span>
+        <div class="option-card">
+          <h3>Ordine di partenza</h3>
+          <div class="toggle-control">
+            <span>Normale</span>
+            <label class="switch">
+              <input type="checkbox" id="start-order-toggle">
+              <span class="slider"></span>
+            </label>
+            <span>Invertito</span>
+          </div>
         </div>
-        <div class="override-box">
+        <div class="option-card override-box">
           <h3>Sovrascrivi partenza</h3>
           <input type="number" id="override-input" placeholder="Numero pettorale">
           <div class="override-actions">
@@ -53,7 +60,7 @@
             <button id="clear-override" class="ghost-button">Annulla</button>
           </div>
         </div>
-        <div class="pointer-box">
+        <div class="option-card pointer-box">
           <h3>Indice partenza</h3>
           <p id="pointer-info">—</p>
           <p class="help-text">Indica la posizione corrente nella lista di partenza.</p>

--- a/html/race-view.html
+++ b/html/race-view.html
@@ -11,6 +11,7 @@
     <div class="navbar-left">Cesana Timing</div>
     <div class="navbar-right">
       <a href="/live" class="nav-link">Tempi</a>
+      <a href="/classifiche" class="nav-link">Classifiche</a>
       <a href="/admin" class="nav-link">Admin</a>
       <button id="theme-toggle" class="theme-toggle">🌙</button>
     </div>

--- a/html/setup.html
+++ b/html/setup.html
@@ -11,6 +11,7 @@
     <div class="navbar-left">Cesana Timing</div>
     <div class="navbar-right">
       <a href="/live" class="nav-link">Tempi</a>
+      <a href="/classifiche" class="nav-link">Classifiche</a>
       <a href="/admin" class="nav-link active">Admin</a>
       <button id="theme-toggle" class="theme-toggle">🌙</button>
     </div>

--- a/html/training-manage.html
+++ b/html/training-manage.html
@@ -11,6 +11,7 @@
     <div class="navbar-left">Cesana Timing</div>
     <div class="navbar-right">
       <a href="/live" class="nav-link">Tempi</a>
+      <a href="/classifiche" class="nav-link">Classifiche</a>
       <a href="/admin" class="nav-link active">Admin</a>
       <button id="theme-toggle" class="theme-toggle">🌙</button>
     </div>

--- a/html/training.html
+++ b/html/training.html
@@ -11,6 +11,7 @@
     <div class="navbar-left">Cesana Timing</div>
     <div class="navbar-right">
       <a href="/live" class="nav-link">Tempi</a>
+      <a href="/classifiche" class="nav-link">Classifiche</a>
       <a href="/admin" class="nav-link">Admin</a>
       <button id="theme-toggle" class="theme-toggle">🌙</button>
     </div>

--- a/src/services/timingService.js
+++ b/src/services/timingService.js
@@ -81,9 +81,14 @@ async function listTimings({ limit = 100, eventId = null } = {}) {
        t.heat_name,
        t.status,
        assocdb.tags.name  AS tag_name,
-       assocdb.tags.color AS tag_color
+       assocdb.tags.color AS tag_color,
+       participant.name  AS participant_name,
+       bib_participant.name AS bib_participant_name
      FROM timings t
      LEFT JOIN assocdb.tags ON t.tag_id = assocdb.tags.uuid
+     LEFT JOIN participants AS participant ON t.participant_id = participant.id
+     LEFT JOIN participants AS bib_participant
+       ON bib_participant.event_id = t.event_id AND bib_participant.bib_number = t.bib_number
      ${where}
      ORDER BY t.created_at DESC
      LIMIT ?`,
@@ -103,7 +108,10 @@ async function listTimings({ limit = 100, eventId = null } = {}) {
 
   return rows.map(r => {
     let displayName;
-    if (r.tag_name) {
+    const participantName = r.participant_name || r.bib_participant_name;
+    if (participantName) {
+      displayName = participantName;
+    } else if (r.tag_name) {
       displayName = r.tag_name;
     } else if (r.bib_number != null) {
       displayName = `Pettorale ${r.bib_number}`;
@@ -119,6 +127,7 @@ async function listTimings({ limit = 100, eventId = null } = {}) {
       name: displayName,
       start_time: r.start_time,
       elapsed: isDnf ? 'DNF' : formatMs(r.elapsed_ms),
+      elapsed_ms: r.elapsed_ms,
       created_at: r.created_at,
       color: r.tag_color,
       best: !isDnf && bestByUuid[key] != null && r.elapsed_ms === bestByUuid[key],

--- a/src/web/app.js
+++ b/src/web/app.js
@@ -21,8 +21,12 @@ const auth = basicAuth({
 });
 
 const protectedPrefixes = ['/setup.html', '/admin', '/api/tags', '/api/db', '/api/events'];
+const publicPaths = ['/api/events/active'];
 
 app.use((req, res, next) => {
+  if (publicPaths.includes(req.path)) {
+    return next();
+  }
   if (
     protectedPrefixes.some(p => req.path === p || req.path.startsWith(p + '/'))
   ) {
@@ -55,6 +59,10 @@ app.get('/', (req, res) => {
 
 app.get('/live', (req, res) => {
   res.sendFile(path.join(__dirname, '..', '..', 'html', 'timing.html'));
+});
+
+app.get('/classifiche', (req, res) => {
+  res.sendFile(path.join(__dirname, '..', '..', 'html', 'classifiche.html'));
 });
 
 app.get('/admin', auth, (req, res) => {

--- a/src/web/routes/events.js
+++ b/src/web/routes/events.js
@@ -6,6 +6,7 @@ const {
   getEventById,
   getEventBySlug,
   getEventByCode,
+  getActiveEvent,
   setActiveEvent,
   closeEvent,
   updateEventConfig,
@@ -62,6 +63,19 @@ router.get('/lookup', async (req, res) => {
       return res.json(event);
     }
     return res.status(400).json({ error: 'Parametro slug o code richiesto' });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+router.get('/active', async (_req, res) => {
+  try {
+    const active = await getActiveEvent();
+    if (!active) {
+      return res.status(404).json({ error: 'Nessun evento attivo' });
+    }
+    const event = await getEventById(active.id);
+    res.json(event);
   } catch (err) {
     res.status(500).json({ error: err.message });
   }


### PR DESCRIPTION
## Summary
- show participant names on timing results by joining participant data
- add a public `/api/events/active` endpoint with a new `/classifiche` page and navigation link
- restrict the live page to the active event, display event info, and add a sorted rankings table
- refresh race management and admin UI elements so desktop layouts stay aligned and buttons share consistent styling

## Testing
- `node --check src/services/timingService.js`
- `node --check src/web/routes/events.js`
- `node --check src/web/app.js`


------
https://chatgpt.com/codex/tasks/task_e_68cfe512a024832a8083addba916cb32